### PR TITLE
types: add value to AttributesFilterValue

### DIFF
--- a/src/endpoints/filters/filters.ts
+++ b/src/endpoints/filters/filters.ts
@@ -34,6 +34,7 @@ export interface AttributesFilterValue {
   name: string;
   id: number;
   productCount: number;
+  value: string;
 }
 
 export interface IdentifierFilterValue {


### PR DESCRIPTION
The response from the filters endpoint also includes a `value` property

https://api-cloud.aboutyou.de/docs/index.html#/filters/fetch-filters

```
curl -X 'GET' \
  'https://api-cloud.aboutyou.de/v1/filters?campaignKey=px%20%7C%20%3CACTUAL_CAMPAIGN_KEY%3E&includeSoldOut=false&with=values' \
  -H 'accept: application/json'
```

```
[
  {
    "id": 9,
    "slug": "categoryShopFilterSizes",
    "name": "Größe",
    "attributeGroupType": "",
    "type": "attributes",
    "values": [
      {
        "name": "4XS",
        "productCount": 485,
        "id": 76605,
        "value": "4xs"
      },
      ...
    ]
  }
]
```