### PR TITLE
chore: don't include tests in released package

### DIFF
--- a/buildPackage.sh
+++ b/buildPackage.sh
@@ -7,6 +7,7 @@ rm -rf compiled/
 rm -rf dist/
 yarn test
 yarn build
+find compiled -name '__tests__' -type d -exec rm -rf "{}" +
 cp -r compiled/ dist/
 cp package.json dist/
 cp LICENSE dist/


### PR DESCRIPTION
Remove tests from the released package to reduce its size. 

Before: 1.5M 
After: 680K